### PR TITLE
Fix optional description for menu items

### DIFF
--- a/src/__tests__/core/entities/CardapioItemEntity.test.ts
+++ b/src/__tests__/core/entities/CardapioItemEntity.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'bun:test';
+import ItemCardapio from '@/core/entities/CardapioItemEntity';
+
+describe('ItemCardapio Entity', () => {
+  it('should allow creation without description', () => {
+    const item = new ItemCardapio('1', 'Suco', 5.5);
+    expect(item.getId()).toBe('1');
+    expect(item.getNome()).toBe('Suco');
+    expect(item.getPreco()).toBe(5.5);
+    expect(item.getDescricao()).toBeUndefined();
+  });
+
+  it('should throw when price is negative', () => {
+    expect(() => new ItemCardapio('2', 'Sanduíche', -1)).toThrow('Preço inválido');
+  });
+
+  it('should update price and check negative values', () => {
+    const item = new ItemCardapio('3', 'Pastel', 4);
+    expect(() => item.alterarPreco(-1)).toThrow('Preço não pode ser negativo');
+    item.alterarPreco(6);
+    expect(item.getPreco()).toBe(6);
+  });
+
+  it('should toggle availability', () => {
+    const item = new ItemCardapio('4', 'Coxinha', 3);
+    expect(item.estaDisponivel()).toBe(true);
+    item.desativar();
+    expect(item.estaDisponivel()).toBe(false);
+    item.ativar();
+    expect(item.estaDisponivel()).toBe(true);
+  });
+});

--- a/src/core/entities/CardapioItemEntity.ts
+++ b/src/core/entities/CardapioItemEntity.ts
@@ -5,7 +5,7 @@ export default class ItemCardapio {
   private descricao?: string;
   private disponivel: boolean;
 
-  constructor(id: string, nome: string, preco: number, descricao: string, disponivel: boolean = true) {
+  constructor(id: string, nome: string, preco: number, descricao?: string, disponivel: boolean = true) {
     if (preco < 0) throw new Error('Preço inválido');
     this.id = id;
     this.nome = nome;


### PR DESCRIPTION
## Summary
- allow optional description in `CardapioItemEntity` constructor
- add unit tests for `ItemCardapio`

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68404d69cf44832981f6b5eba4ddde9c