### PR TITLE
Fix X-Burger spelling in seed

### DIFF
--- a/seed.ts
+++ b/seed.ts
@@ -31,7 +31,7 @@ async function seed() {
       id: randomUUID(),
       empresaId,
       cardapioId,
-      nome: 'X-Burguer',
+      nome: 'X-Burger',
       descricao: 'Pão, carne e queijo',
       preco: '18.90',
       disponivel: true,


### PR DESCRIPTION
## Summary
- fix typo in seed.ts so seeded item matches spelling in MensagemHandler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68404f35e4f48329b47753e1a0ce2159